### PR TITLE
Add offline prototype exporter plugin

### DIFF
--- a/figma-local-prototype/code.ts
+++ b/figma-local-prototype/code.ts
@@ -1,0 +1,49 @@
+figma.showUI(__html__, { width: 300, height: 200 });
+
+figma.ui.onmessage = async (msg) => {
+  if (msg.type === 'generate') {
+    const name = msg.name || 'prototype';
+    const selection = figma.currentPage.selection.filter(node => node.type === 'FRAME') as FrameNode[];
+    if (selection.length === 0) {
+      figma.notify('Please select frames before running the plugin.');
+      figma.ui.postMessage({ type: 'error', message: 'No frames selected' });
+      return;
+    }
+
+    const frameIndex: Record<string, number> = {};
+    selection.forEach((frame, i) => {
+      frameIndex[frame.id] = i;
+    });
+
+    const framesData = [] as any[];
+    for (let i = 0; i < selection.length; i++) {
+      const frame = selection[i];
+      const bytes = await frame.exportAsync({ format: 'PNG' });
+      const b64 = figma.base64Encode(bytes);
+      const links: any[] = [];
+      const frameBox = frame.absoluteBoundingBox!;
+      const nodes = frame.findAll(n => n.reactions && n.reactions.length > 0);
+      for (const node of nodes) {
+        const bbox = node.absoluteBoundingBox;
+        if (!bbox) continue;
+        for (const reaction of node.reactions) {
+          if (reaction.action.type === 'NODE' && reaction.trigger.type === 'ON_CLICK') {
+            const destIndex = frameIndex[reaction.action.destinationId!];
+            if (destIndex !== undefined) {
+              links.push({
+                x: bbox.x - frameBox.x,
+                y: bbox.y - frameBox.y,
+                w: bbox.width,
+                h: bbox.height,
+                target: destIndex
+              });
+            }
+          }
+        }
+      }
+      framesData.push({ index: i, width: frame.width, height: frame.height, b64, links });
+    }
+
+    figma.ui.postMessage({ type: 'data', name, frames: framesData });
+  }
+};

--- a/figma-local-prototype/manifest.json
+++ b/figma-local-prototype/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "Local Prototype Exporter",
+  "id": "figma-local-prototype-exporter",
+  "api": "1.0.0",
+  "main": "code.ts",
+  "ui": "ui.html"
+}

--- a/figma-local-prototype/ui.html
+++ b/figma-local-prototype/ui.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body { font-family: sans-serif; padding: 16px; }
+    label { display: block; margin-bottom: 8px; }
+    #generate { margin-top: 12px; }
+  </style>
+</head>
+<body>
+  <label>
+    Prototype name:
+    <input id="name" type="text" placeholder="MyPrototype" />
+  </label>
+  <button id="generate">Generate local prototype</button>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.7.1/jszip.min.js"></script>
+  <script src="ui.js"></script>
+</body>
+</html>

--- a/figma-local-prototype/ui.js
+++ b/figma-local-prototype/ui.js
@@ -1,0 +1,40 @@
+const generateBtn = document.getElementById('generate');
+
+generateBtn.onclick = () => {
+  const name = (document.getElementById('name')).value || 'prototype';
+  parent.postMessage({ pluginMessage: { type: 'generate', name } }, '*');
+};
+
+onmessage = async (event) => {
+  const msg = event.data.pluginMessage;
+  if (!msg) return;
+  if (msg.type === 'error') {
+    alert(msg.message);
+  }
+  if (msg.type === 'data') {
+    const { name, frames } = msg;
+    const zip = new JSZip();
+    const folder = zip.folder(name);
+    frames.forEach(f => {
+      folder.file(`frame${f.index}.png`, f.b64, { base64: true });
+    });
+    const transitions = `const frames = ${JSON.stringify(frames.map(f => ({ w: f.width, h: f.height, img: 'frame' + f.index + '.png', links: f.links })))};\n` +
+      `let current = 0;\n` +
+      `function showFrame(i){current=i;const fr=frames[i];const cont=document.getElementById('frame');cont.style.width=fr.w+'px';cont.style.height=fr.h+'px';cont.innerHTML='<img src="'+fr.img+'" style="width:100%;height:100%;">';fr.links.forEach(l=>{const a=document.createElement('a');a.style.position='absolute';a.style.left=l.x+'px';a.style.top=l.y+'px';a.style.width=l.w+'px';a.style.height=l.h+'px';a.href='javascript:showFrame('+l.target+')';cont.appendChild(a);});}\n` +
+      `function next(){if(current<frames.length-1)showFrame(current+1);}\n` +
+      `function prev(){if(current>0)showFrame(current-1);}\n` +
+      `function restart(){showFrame(0);}\n` +
+      `window.onload=()=>showFrame(0);`;
+    folder.file('transitions.js', transitions);
+    const html = `<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><style>body{margin:0;}#controls{position:fixed;bottom:10px;right:10px;}#frame{position:relative;}</style></head><body><div id=\"frame\"></div><div id=\"controls\"><button onclick=\"prev()\">\u25C0</button><button onclick=\"next()\">\u25B6</button><button onclick=\"restart()\">\u21BA</button></div><script src=\"transitions.js\"></script></body></html>`;
+    folder.file('index.html', html);
+    const content = await zip.generateAsync({ type: 'uint8array' });
+    const blob = new Blob([content], { type: 'application/zip' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = name + '.zip';
+    a.click();
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+};


### PR DESCRIPTION
## Summary
- add Figma plugin for exporting local prototype

## Testing
- `node --check figma-local-prototype/ui.js`
- `npx ts-node --transpile-only figma-local-prototype/code.ts` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68406498707c8331aae22c76f27b5ec9